### PR TITLE
Add support for Scala 3.3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,3 +3,4 @@ runner.dialect = scala213
 align.preset = more
 maxColumn = 120
 rewrite.rules = [AsciiSortImports,AvoidInfix,SortModifiers]
+project.layout = StandardConvention

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,21 @@ lazy val commonSettings = Seq(
   organization       := "ch.megard",
   version            := "0.0.0-SNAPSHOT",
   scalaVersion       := "2.13.10",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.17", "3.2.2"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.17", "3.3.0"),
   scalacOptions ++= Seq(
     "-encoding",
     "UTF-8",
     "-unchecked",
     "-deprecation"
-  ),
+  ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n == 12 || n == 13 =>
+      Seq(
+        "-opt:l:inline",
+        "-opt-inline-from:<sources>"
+      )
+    case Some((3, n)) =>
+      Seq.empty // Inliner doesn't exist for Scala 3 yet
+  }),
   javacOptions ++= Seq(
     "-encoding",
     "UTF-8",
@@ -49,8 +57,8 @@ lazy val root = (project in file("."))
   .settings(dontPublishSettings)
 
 // Until stable look for latest version at https://repository.apache.org/content/groups/snapshots/org/apache/pekko/
-lazy val pekkoVersion     = "0.0.0+26605-0a8b8a57-SNAPSHOT"
-lazy val pekkoHttpVersion = "0.0.0+4329-fad15dd0-SNAPSHOT"
+lazy val pekkoVersion     = "0.0.0+26669-ec5b6764-SNAPSHOT"
+lazy val pekkoHttpVersion = "0.0.0+4411-6fe04045-SNAPSHOT"
 
 lazy val `pekko-http-cors` = project
   .settings(commonSettings)
@@ -60,11 +68,11 @@ lazy val `pekko-http-cors` = project
     Compile / packageBin / packageOptions += Package.ManifestAttributes(
       "Automatic-Module-Name" -> "ch.megard.pekko.http.cors"
     ),
-    libraryDependencies += "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion cross CrossVersion.for3Use2_13,
-    libraryDependencies += "org.apache.pekko" %% "pekko-stream" % pekkoVersion % Provided cross CrossVersion.for3Use2_13,
-    libraryDependencies += "org.apache.pekko" %% "pekko-http-testkit" % pekkoHttpVersion % Test cross CrossVersion.for3Use2_13,
-    libraryDependencies += "org.apache.pekko" %% "pekko-stream-testkit" % pekkoVersion % Test cross CrossVersion.for3Use2_13,
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15" % Test
+    libraryDependencies += "org.apache.pekko" %% "pekko-http"           % pekkoHttpVersion,
+    libraryDependencies += "org.apache.pekko" %% "pekko-stream"         % pekkoVersion     % Provided,
+    libraryDependencies += "org.apache.pekko" %% "pekko-http-testkit"   % pekkoHttpVersion % Test,
+    libraryDependencies += "org.apache.pekko" %% "pekko-stream-testkit" % pekkoVersion     % Test,
+    libraryDependencies += "org.scalatest"    %% "scalatest"            % "3.2.15"         % Test
   )
 
 lazy val `pekko-http-cors-example` = project
@@ -72,7 +80,7 @@ lazy val `pekko-http-cors-example` = project
   .settings(commonSettings)
   .settings(dontPublishSettings)
   .settings(
-    libraryDependencies += "org.apache.pekko" %% "pekko-stream" % pekkoVersion cross CrossVersion.for3Use2_13
+    libraryDependencies += "org.apache.pekko" %% "pekko-stream" % pekkoVersion
     // libraryDependencies += "ch.megard" %% "pekko-http-cors" % version.value
   )
 
@@ -82,5 +90,5 @@ lazy val `pekko-http-cors-bench-jmh` = project
   .settings(commonSettings)
   .settings(dontPublishSettings)
   .settings(
-    libraryDependencies += "org.apache.pekko" %% "pekko-stream" % pekkoVersion cross CrossVersion.for3Use2_13
+    libraryDependencies += "org.apache.pekko" %% "pekko-stream" % pekkoVersion
   )

--- a/pekko-http-cors/src/main/scala-2.12/ch/megard/pekko/http/cors/OptionConverters.scala
+++ b/pekko-http-cors/src/main/scala-2.12/ch/megard/pekko/http/cors/OptionConverters.scala
@@ -1,0 +1,8 @@
+package ch.megard.pekko.http.cors
+
+import java.util.Optional
+
+private object OptionConverters {
+  @inline final def toScala[A](o: Optional[A]): Option[A] = scala.compat.java8.OptionConverters.toScala(o)
+  @inline final def toJava[A](o: Option[A]): Optional[A]  = scala.compat.java8.OptionConverters.toJava(o)
+}

--- a/pekko-http-cors/src/main/scala-2.13/ch/megard/pekko/http/cors/OptionConverters.scala
+++ b/pekko-http-cors/src/main/scala-2.13/ch/megard/pekko/http/cors/OptionConverters.scala
@@ -1,0 +1,8 @@
+package ch.megard.pekko.http.cors
+
+import java.util.Optional
+
+object OptionConverters {
+  @inline final def toScala[A](o: Optional[A]): Option[A] = scala.jdk.javaapi.OptionConverters.toScala(o)
+  @inline final def toJava[A](o: Option[A]): Optional[A]  = scala.jdk.javaapi.OptionConverters.toJava(o)
+}

--- a/pekko-http-cors/src/main/scala-3/ch/megard/pekko/http/cors/OptionConverters.scala
+++ b/pekko-http-cors/src/main/scala-3/ch/megard/pekko/http/cors/OptionConverters.scala
@@ -1,0 +1,8 @@
+package ch.megard.pekko.http.cors
+
+import java.util.Optional
+
+object OptionConverters {
+  final inline def toScala[A](o: Optional[A]): Option[A] = scala.jdk.javaapi.OptionConverters.toScala(o)
+  final inline def toJava[A](o: Option[A]): Optional[A]  = scala.jdk.javaapi.OptionConverters.toJava(o)
+}

--- a/pekko-http-cors/src/main/scala/ch/megard/pekko/http/cors/scaladsl/settings/CorsSettings.scala
+++ b/pekko-http-cors/src/main/scala/ch/megard/pekko/http/cors/scaladsl/settings/CorsSettings.scala
@@ -9,12 +9,12 @@ import org.apache.pekko.http.scaladsl.model.headers.HttpOrigin
 import org.apache.pekko.http.scaladsl.model.{HttpHeader, HttpMethod, HttpMethods}
 import ch.megard.pekko.http.cors.javadsl
 import ch.megard.pekko.http.cors.scaladsl.model.{HttpHeaderRange, HttpOriginMatcher}
+import ch.megard.pekko.http.cors.OptionConverters
 import com.typesafe.config.ConfigException.{Missing, WrongType}
 import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.{ListMap, Seq}
-import scala.compat.java8.OptionConverters
 import scala.util.Try
 
 /** Settings used by the CORS directives.


### PR DESCRIPTION
Pekko and Pekko Http latest snapshots have just been released with Scala 3.3 support. This PR updates pekko-http-cors so that it properly releases Scala 3 artifacts instead of using `CrossVersion.for3Use2_13` (which actually should not be used for libraries, for applications its fine).

You may have noticed the addition of the inline settings as well as `ch.megard.pekko.http.cors.OptionConverters`, this is due to the fact that the latest version of Pekko has dropped `java8-scala-compat` for Scala 2.13+ (its still needed for 2.12) and so this technique is used to cross compile `ObjectConverters` for all versions of Scala that this project supports.

An alternative to this inlining solution would have been just to add `java8-scala-compat` as a dependency. The problem here is that it since pekko-grpc relies on this library, adding `java8-scala-compat` as a dependency would have made the endeavour somewhat pointless as Pekko module aside from pekko core/pekko-http would have had this dependency transitively introduced.

@lomigmegard Can you let me know when you release a new artifact. Thanks!